### PR TITLE
scrollView的引用未使用弱引用导致内存泄漏视图不释放

### DIFF
--- a/JRefresh/Base/JRefreshComponent.swift
+++ b/JRefresh/Base/JRefreshComponent.swift
@@ -57,7 +57,7 @@ open class JRefreshComponent: UIView {
     /// 记录scrollView刚开始的inset
     var scrollViewOriginalInset: UIEdgeInsets?
     ///父控件
-    private(set) var scrollView: UIScrollView?
+    private(set) weak var scrollView: UIScrollView?
     
     //MARK: - 其他
     ///拉拽的百分比(交给子类重写)


### PR DESCRIPTION
视图销毁后，发现scrollView不自动释放